### PR TITLE
Add Wonderland Engine community curated example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ These examples are maintained by members of the Discord Developer Community.
 | | |
 |-|-|
 | [Colyseus](https://github.com/colyseus/discord-embedded-app-sdk) | This example uses Node.js, React, and [Colyseus](https://colyseus.io/), a multiplayer JS framework, to demonstrate state management in a multiplayer experience.  |
+| [Wonderland Engine](https://github.com/WonderlandEngine/discord-activity-example) | This example uses [Wonderland Engine](https://wonderlandengine.com) and Node.js to demonstrate performant 3D rendering inside an Embedded App. |
 
 ## Discord Developer Terms of Service & Developer Policy
 


### PR DESCRIPTION
Hey everybody!

We just added a [Discord Activity Example](https://github.com/WonderlandEngine/discord-activity-example) for [Wonderland Engine](https://wonderlandengine.com).

Would appreciate if it could be added to the list of community curated examples!

Thanks and best,
Jonathan