### PR TITLE
fix(deploy): run pnpm install in sdk-playground production deploy

### DIFF
--- a/.github/workflows/sdk-playground-production.yml
+++ b/.github/workflows/sdk-playground-production.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
+      - run: pnpm install
       - name: create env file
         run: |
           cd sdk-playground


### PR DESCRIPTION
the workflow is failing https://github.com/discord/embedded-app-sdk-examples/actions/runs/11146563266/job/30978813597 

with this error 
```
error TS2688: Cannot find type definition file for '@cloudflare/workers-types'.
  The file is in the program because:
    Entry point of type library '@cloudflare/workers-types' specified in compilerOptions
 ELIFECYCLE  Command failed with exit code 2.
 WARN   Local package.json exists, but node_modules missing, did you mean to install?
 
