### PR TITLE
chore(deploy): use wrangler pages deploy instead of deprecated publish

### DIFF
--- a/.github/workflows/sdk-playground-production.yml
+++ b/.github/workflows/sdk-playground-production.yml
@@ -32,7 +32,7 @@ jobs:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           workingDirectory: sdk-playground/packages/client
-          command: pages publish --project-name=sdk-playground dist
+          command: pages deploy --project-name=sdk-playground dist
           wranglerVersion: '3.52.0'
       - name: deploy server
         uses: cloudflare/wrangler-action@v3.8.0


### PR DESCRIPTION
addressing warning from last CI run 
```
▲ [WARNING] `wrangler pages publish` is deprecated and will be removed in the next major version.
  
    Please use `wrangler pages deploy` instead, which accepts exactly the same arguments.
```