### PR TITLE
fix: convert share link input into textarea

### DIFF
--- a/sdk-playground/packages/client/src/App.tsx
+++ b/sdk-playground/packages/client/src/App.tsx
@@ -252,8 +252,12 @@ function RootedApp(): React.ReactElement {
   const navigate = useNavigate();
 
   React.useEffect(() => {
-    if (navigateOnInit && discordSdk.customId === 'PAGE_GET_SKUS') {
-      navigate('/get-skus');
+    if (navigateOnInit === false || typeof discordSdk.customId !== 'string') {
+      return;
+    }
+
+    if (routes.hasOwnProperty(discordSdk.customId) && 'path' in routes[discordSdk.customId]) {
+      navigate(routes[discordSdk.customId].path);
       navigateOnInit = false;
     }
   }, [navigate]);


### PR DESCRIPTION
* share link is now a textarea so you can compose a nicely formatted message
* populating the referrer_id with the user_id automatically
* unrelated: made customId navigate to any page in the sdk playground