### PR TITLE
chore(deps): update discord/embedded-app-sdk to v2.0.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,8 +99,8 @@ importers:
   sdk-playground/packages/client:
     dependencies:
       '@discord/embedded-app-sdk':
-        specifier: ^1.9.0
-        version: 1.9.0
+        specifier: ^2.0.0
+        version: 2.0.0
       '@radix-ui/colors':
         specifier: ^3.0.0
         version: 3.0.0
@@ -406,8 +406,8 @@ packages:
   '@discord/embedded-app-sdk@1.7.0':
     resolution: {integrity: sha512-lHoDTtNzJlrajlmXhbjQukl07GwUKH91CqVqr8lEYyOPu8uiAZJZ3E7yx6EX53kert2z8w7ksYVnE9TZzbvb2Q==}
 
-  '@discord/embedded-app-sdk@1.9.0':
-    resolution: {integrity: sha512-aesQGKyhQgcxuY4/iJoylFfFaynZeU70Y5nqDtFNQ6Hs11LH+Xly7CfD6AhkTNssIyLljEkxG5ZYLU6Bj6n1kw==}
+  '@discord/embedded-app-sdk@2.0.0':
+    resolution: {integrity: sha512-84XSrJdCLBvOiH8lb0kUjWpiNZlPVU0FBIjbCrndoEFB26z2Xki7Mv9Dh+gLh21NzE9ExkN9PxeInV0R4XD0Kg==}
 
   '@esbuild-plugins/node-globals-polyfill@0.2.3':
     resolution: {integrity: sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==}
@@ -2892,7 +2892,7 @@ snapshots:
       uuid: 10.0.0
       zod: 3.23.8
 
-  '@discord/embedded-app-sdk@1.9.0':
+  '@discord/embedded-app-sdk@2.0.0':
     dependencies:
       '@types/lodash.transform': 4.6.9
       '@types/uuid': 10.0.0

--- a/sdk-playground/packages/client/package.json
+++ b/sdk-playground/packages/client/package.json
@@ -13,7 +13,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@discord/embedded-app-sdk": "^1.9.0",
+    "@discord/embedded-app-sdk": "^2.0.0",
     "@radix-ui/colors": "^3.0.0",
     "@radix-ui/react-scroll-area": "^1.0.1",
     "@stitches/react": "^1.2.1",

--- a/sdk-playground/packages/client/src/pages/ShareLink.tsx
+++ b/sdk-playground/packages/client/src/pages/ShareLink.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
-import {useLocation} from 'react-router-dom';
 import discordSdk from '../discordSdk';
-import {EventPayloadData} from '@discord/embedded-app-sdk';
 
 export default function ShareLink() {
   const [message, setMessage] = React.useState<string>('Come Play SDK Playground!');
   const [customId, setCustomId] = React.useState<string | undefined >(undefined);
-  const [referrerId, setReferrerId] = React.useState<string | undefined >(undefined);
 
   const [hasPressedSend, setHasPressedSend] = React.useState<boolean>(false);
   const [didSend, setDidSend] = React.useState<boolean>(false);
@@ -17,30 +14,11 @@ export default function ShareLink() {
   const handleCustomIdChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setCustomId(event.target.value);
   };
-  const handleReferrerIdChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setReferrerId(event.target.value);
-  };
-
-  const location = useLocation();
-
-  React.useEffect(() => {
-    const {channelId} = discordSdk;
-    if (!channelId) return;
-
-    const handleCurrentUserUpdate = (currentUserEvent: EventPayloadData<'CURRENT_USER_UPDATE'>) => {
-      setReferrerId(currentUserEvent.id);
-    };
-    discordSdk.subscribe('CURRENT_USER_UPDATE', handleCurrentUserUpdate);
-    return () => {
-      discordSdk.unsubscribe('CURRENT_USER_UPDATE', handleCurrentUserUpdate);
-    };
-  }, [location.search]);
 
   const doShareLink = async () => {
     const { success} = await discordSdk.commands.shareLink({
       message,
       custom_id: customId,
-      referrer_id: referrerId,
     });
     setHasPressedSend(true);
     setDidSend(success);
@@ -62,15 +40,6 @@ export default function ShareLink() {
         value={customId}
         onChange={handleCustomIdChange}
         placeholder="What's your custom ID?"
-        style={{ width: '400px', padding: '8px' }}
-      />
-      <br/>
-      <p> Referrer ID: </p>
-      <input
-        type="text"
-        value={referrerId}
-        onChange={handleReferrerIdChange}
-        placeholder="What's your referrer ID?"
         style={{ width: '400px', padding: '8px' }}
       />
       <br/>


### PR DESCRIPTION
Removing `referrer_id` from sdk-playground in preparation for the incoming upgrade to embedded-app-sdk 2

Ref: https://github.com/discord/embedded-app-sdk/pull/307